### PR TITLE
try to cache the data from the api calls in a basic text file

### DIFF
--- a/app/bills.php
+++ b/app/bills.php
@@ -4,6 +4,7 @@ error_reporting(0);
 header('Content-Type: application/json');
 
 require('config.php');
+require('cache-or-curl.php');
 
 $state = isset($_GET['state']) ? $_GET['state'] : null;
 $session = isset($_GET['session']) ? $_GET['session'] : null;
@@ -23,17 +24,11 @@ $data = array(
   'apikey' => API_KEY
 );
 
-// Make API call
-$curl = curl_init();
-curl_setopt($curl, CURLOPT_URL, sprintf("%s?%s", $url, http_build_query($data)));
-curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-curl_setopt($curl, CURLOPT_HEADER, 0);
 
-// Store API Result
-$result = curl_exec($curl);
+// replace curl call with function that caches, or loads from cache
+$file_name = 'bills.txt';
+$result = get_content($file_name, $args);
 
-// Terminate cURL
-curl_close($curl);
 
 // Store results as JSON
 $data = json_decode($result, true);

--- a/app/cache-or-curl.php
+++ b/app/cache-or-curl.php
@@ -1,0 +1,40 @@
+<?php
+
+// quick and dirty cache from https://davidwalsh.name/php-cache-function
+// change the $hours = 24 to however many hours the data should be stored, if 1 day is not correct
+
+// gets the contents of $file if it exists
+// otherwise grabs from the url based on the $data and caches
+function get_content($file, $data, $hours = 24, $fn = '', $fn_args = '') {
+	//vars
+	$current_time = time(); $expire_time = $hours * 60 * 60; $file_time = filemtime($file);
+	//decisions, decisions
+	if(file_exists($file) && ($current_time - $expire_time < $file_time)) {
+		//echo 'returning from cached file';
+		return file_get_contents($file);
+	}
+	else {
+		$content = get_url($data);
+		if($fn) { $content = $fn($content, $fn_args); }
+		$content.= '<!-- cached:  '.time().'-->';
+		file_put_contents($file, $content);
+		//echo 'retrieved fresh from '.$data.':: '.$content;
+		return $content;
+	}
+}
+
+/* gets content from a URL via curl */
+function get_url($data) {
+	// Make API call
+	$curl = curl_init();
+	curl_setopt($curl, CURLOPT_URL, sprintf("%s?%s", API_URL_LEGISLATORS, http_build_query($data)));
+	curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+	curl_setopt($curl, CURLOPT_HEADER, 0);
+
+	// Store API Result
+	$result = curl_exec($curl);
+
+	// Terminate cURL
+	curl_close($curl);
+	return $result;
+}

--- a/app/legislators.php
+++ b/app/legislators.php
@@ -4,6 +4,7 @@ error_reporting(0);
 header('Content-Type: application/json');
 
 require('config.php');
+require('cache-or-curl.php');
 
 $latitude = isset($_GET['latitude']) ? $_GET['latitude'] : null;
 $longitude = isset($_GET['longitude']) ? $_GET['longitude'] : null;
@@ -32,17 +33,11 @@ $data = array(
   'long' => $longitude
 );
 
-// Make API call
-$curl = curl_init();
-curl_setopt($curl, CURLOPT_URL, sprintf("%s?%s", API_URL_LEGISLATORS, http_build_query($data)));
-curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-curl_setopt($curl, CURLOPT_HEADER, 0);
 
-// Store API Result
-$result = curl_exec($curl);
+// replace curl call with function that caches, or loads from cache
+$file_name = 'legislators.txt';
+$result = get_content($file_name, $args);
 
-// Terminate cURL
-curl_close($curl);
 
 // Store results as JSON
 $results = json_decode($result, true);


### PR DESCRIPTION
This puts in a really basic cache function, and uses it in /app/bills.php and /app/legislators.php. It should do these things:
1. Try to create a file called bills.txt or legislators.txt with the results from the API call (it should create it in the same folder as the PHP files).
2. Store it for 24 hours (configurable in /app/cache-or-curl.php)
3. Load it instead of making an API call if it exists and is not expired.
