### PR TITLE
Add aria-label to email field

### DIFF
--- a/app/template/form.html
+++ b/app/template/form.html
@@ -2,7 +2,7 @@
   <h2></h2>
   <p class="intro">Where does your rep stand?</p>
   <form id="campaign-zero-form">
-    <input autocomplete="off" type="text" name="location" id="address" placeholder="Enter your Street Address" onfocus="this.placeholder=''" onblur="this.placeholder='Enter your Street Address'">
+    <input autocomplete="off" type="text" name="location" id="address" aria-label="Enter your Street Address" placeholder="Enter your Street Address" onfocus="this.placeholder=''" onblur="this.placeholder='Enter your Street Address'">
     <small class="note"></small>
     <button class="submit" type="submit"></button>
   </form>


### PR DESCRIPTION
#### What's this PR do?

Adds an accessible label (via `aria-label`) to the initial email field. This is a bare minimum change which doesn't change the UI in any way. To take this a step further in terms of accessibility, I'd recommend using some sort of label which stays visible all the time (see https://www.w3.org/WAI/tutorials/forms/instructions/#placeholder-text) but I didn't want to make any major changes without your approval. If you are open to it, I could take a stab at implementing one of those placeholder which animates into a label above the input things 😄

#### Where should the reviewer start?

This changes makes use of the [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) attribute which will consistently announce to all major screen readers. This helps users with disabilities interact with the form field.

#### How should this be manually tested?

Feel free to turn a screenreader on and test it out!

#### Any background context you want to provide?

#### What are the relevant github issue?

None but I am more than happy to create one if need be - just let me know

#### Screenshots (if appropriate)

#### What gif best describes this PR or how it makes you feel?

![thumbs up](https://media.giphy.com/media/lYpOXbTyaTF60/giphy.gif)

#### Definition of Done:

- [x] You have actually run this locally and can verify it works
- [x] You have added code comments to all code being submitted
- [x] You have updated the README file (if appropriate)
